### PR TITLE
Task 6

### DIFF
--- a/project/__init__.py
+++ b/project/__init__.py
@@ -6,3 +6,6 @@ from project.automata import *
 
 import project.matrix_utils
 from project.matrix_utils import *
+
+import project.cfg_utils
+from project.cfg_utils import *

--- a/project/cfg_utils.py
+++ b/project/cfg_utils.py
@@ -1,0 +1,27 @@
+from typing import Union
+
+from pyformlang.cfg import CFG, Variable
+
+__all__ = [
+    "cfg_to_wcnf",
+    "cfg_from_file",
+]
+
+from typing.io import IO
+
+
+def cfg_to_wcnf(cfg: CFG) -> CFG:
+    cleared = (
+        cfg.remove_useless_symbols()
+        .eliminate_unit_productions()
+        .remove_useless_symbols()
+    )
+    productions = cleared._decompose_productions(
+        cleared._get_productions_with_only_single_terminals()
+    )
+    return CFG(start_symbol=cleared.start_symbol, productions=set(productions))
+
+
+def cfg_from_file(file: Union[str, IO], start_symbol=Variable("S")) -> CFG:
+    with open(file) as f:
+        return CFG.from_text(f.read(), start_symbol=start_symbol)

--- a/project/cfg_utils.py
+++ b/project/cfg_utils.py
@@ -1,13 +1,12 @@
 from typing import Union
 
 from pyformlang.cfg import CFG, Variable
+from typing.io import IO
 
 __all__ = [
     "cfg_to_wcnf",
     "cfg_from_file",
 ]
-
-from typing.io import IO
 
 
 def cfg_to_wcnf(cfg: CFG) -> CFG:

--- a/project/cfg_utils.py
+++ b/project/cfg_utils.py
@@ -10,6 +10,18 @@ __all__ = [
 
 
 def cfg_to_wcnf(cfg: CFG) -> CFG:
+    """Converts CFG to Weak Chomsky Normal Form
+
+    Parameters
+    ----------
+    cfg : CFG
+        Context free grammar
+
+    Returns
+    -------
+    wcnf: CFG
+        Converted cfg
+    """
     cleared = (
         cfg.remove_useless_symbols()
         .eliminate_unit_productions()
@@ -21,6 +33,22 @@ def cfg_to_wcnf(cfg: CFG) -> CFG:
     return CFG(start_symbol=cleared.start_symbol, productions=set(productions))
 
 
-def cfg_from_file(file: Union[str, IO], start_symbol=Variable("S")) -> CFG:
+def cfg_from_file(
+    file: Union[str, IO], start_symbol: Union[str, Variable] = Variable("S")
+) -> CFG:
+    """Loads CFG from file
+
+    Parameters
+    ----------
+    file : Union[str, IO]
+        Filename or file itself
+    start_symbol : Union[str, Variable]
+        The start symbol for the CFG to be loaded
+
+    Returns
+    -------
+    cfg: CFG
+        Loaded CFG
+    """
     with open(file) as f:
         return CFG.from_text(f.read(), start_symbol=start_symbol)

--- a/tests/test_cfg_from_file.py
+++ b/tests/test_cfg_from_file.py
@@ -1,0 +1,43 @@
+import pytest
+
+from pyformlang.cfg import Production, Variable, Terminal
+from project.cfg_utils import *
+
+
+@pytest.mark.parametrize(
+    "cfg_as_text",
+    ["", "A -> b"],
+)
+def test_empty_cfg_from_file(tmpdir, cfg_as_text):
+    file = tmpdir.mkdir("test_dir").join("some_cfg_file")
+    file.write(cfg_as_text)
+    cfg = cfg_from_file(file)
+    assert cfg.is_empty()
+
+
+@pytest.mark.parametrize(
+    "cfg_as_text, expected_productions",
+    [
+        ("", set()),
+        ("S -> a", {Production(Variable("S"), [Terminal("a")])}),
+        (
+            """
+            S -> epsilon
+            S -> a S b
+            S -> S S
+            """,
+            {
+                Production(Variable("S"), []),
+                Production(
+                    Variable("S"), [Terminal("a"), Variable("S"), Terminal("b")]
+                ),
+                Production(Variable("S"), [Variable("S"), Variable("S")]),
+            },
+        ),
+    ],
+)
+def test_cfg_from_file(tmpdir, cfg_as_text, expected_productions):
+    file = tmpdir.mkdir("test_dir").join("some_cfg_file")
+    file.write(cfg_as_text)
+    cfg = cfg_from_file(file)
+    assert cfg.productions == expected_productions

--- a/tests/test_cfg_to_wcnf.py
+++ b/tests/test_cfg_to_wcnf.py
@@ -72,7 +72,7 @@ def test_conversion_to_wcnf(cfg, expected_productions):
         ),
     ],
 )
-def test_both_form_accept_same(cfg, words):
+def test_both_forms_accept_same(cfg, words):
     cfg = CFG.from_text(cfg)
     wcnf = cfg_to_wcnf(cfg)
     assert all(cfg.contains(word) == wcnf.contains(word) for word in words)

--- a/tests/test_cfg_to_wcnf.py
+++ b/tests/test_cfg_to_wcnf.py
@@ -42,7 +42,7 @@ from project.cfg_utils import *
         ),
     ],
 )
-def test_generated_words(cfg, expected_productions):
+def test_conversion_to_wcnf(cfg, expected_productions):
     cfg_wcnf = cfg_to_wcnf(CFG.from_text(cfg))
     assert cfg_wcnf.productions == expected_productions
 

--- a/tests/test_cfg_to_wcnf.py
+++ b/tests/test_cfg_to_wcnf.py
@@ -28,7 +28,7 @@ from project.cfg_utils import *
         ),
         (
             """
-            S ->  
+            S ->
             S -> a S b S
             """,
             {

--- a/tests/test_cfg_to_wcnf.py
+++ b/tests/test_cfg_to_wcnf.py
@@ -1,0 +1,78 @@
+import pytest
+from pyformlang.cfg import CFG, Terminal, Variable, Production
+
+from project.cfg_utils import *
+
+
+@pytest.mark.parametrize(
+    "cfg, expected_productions",
+    [
+        (
+            """
+            S -> S
+            """,
+            set(),
+        ),
+        (
+            """
+            A -> b
+            """,
+            set(),
+        ),
+        (
+            """
+            S -> T
+            T -> t
+            """,
+            {Production(Variable("S"), [Terminal("t")])},
+        ),
+        (
+            """
+            S ->  
+            S -> a S b S
+            """,
+            {
+                Production(Variable("S"), []),
+                Production(Variable("S"), [Variable("a#CNF#"), Variable("C#CNF#1")]),
+                Production(Variable("a#CNF#"), [Terminal("a")]),
+                Production(Variable("b#CNF#"), [Terminal("b")]),
+                Production(Variable("C#CNF#1"), [Variable("S"), Variable("C#CNF#2")]),
+                Production(Variable("C#CNF#2"), [Variable("b#CNF#"), Variable("S")]),
+            },
+        ),
+    ],
+)
+def test_generated_words(cfg, expected_productions):
+    cfg_wcnf = cfg_to_wcnf(CFG.from_text(cfg))
+    assert cfg_wcnf.productions == expected_productions
+
+
+@pytest.mark.parametrize(
+    "cfg, words",
+    [
+        (
+            """
+            S -> S
+            """,
+            ["", "abc"],
+        ),
+        (
+            """
+            S -> T
+            T -> t
+            """,
+            ["", "t", "a"],
+        ),
+        (
+            """
+            S ->
+            S -> a S b S
+            """,
+            ["", "ab", "ba", "aabb", "abba", "abab"],
+        ),
+    ],
+)
+def test_both_form_accept_same(cfg, words):
+    cfg = CFG.from_text(cfg)
+    wcnf = cfg_to_wcnf(cfg)
+    assert all(cfg.contains(word) == wcnf.contains(word) for word in words)


### PR DESCRIPTION
# Задача 6. Преобразование грамматики в ОНФХ

* **Мягкий дедлайн**: 23.10.2022, 23:59
* **Жёсткий дедлайн**: 26.10.2022, 23:59
* Полный балл: 2

## Определение ОНФХ

Контекстно-свободная грамматика находится в ослабленной нормальной форме Хомского (ОНФХ) тогда и только тогда, когда все её правила имеют следующий вид
1. ```A -> B C```
2. ```A -> a```
3. ```A -> eps```

, где ```A, B, C``` -- произвольные нетерминалы, ```a``` -- произвольный терминал, ```eps```--- обозначение для эпсилон.

Отличия от нормальной формы Хомского (НФХ).
1. Эпсилон может выводиться из любого нетерминала.
2. Стартовый нетерминал может встречаться в правых частях правил.


## Задача

- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html) реализовать **функцию** преобразования контекстно-свободной грамматики в ослабленную нормальную форму Хомского (ОНФХ), но не классическую нормальную форму Хомского (НФХ). НФХ является частным случаем ОНФХ, а значит можно утверждать, что грамматика, находящаяся в НФХ находится и в ОНФХ. Но в данной задаче нас интересует максимально слабая форма, то есть ОНФХ, но не НФХ.
- [x] Предусмотреть возможность чтения грамматики из файла. Формат файла определяется возможностями pyformalng. Например, можно использовать [эту функцию](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html#pyformlang.cfg.CFG.from_text).
- [x] Добавить необходимые тесты.